### PR TITLE
Fixes for a pair of direct porting issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var hasOwn = Object.prototype.hasOwnProperty
+
 function isPlainObject(obj) {
 	if (!obj || toString.call(obj) !== '[object Object]' || obj.nodeType || obj.setInterval)
 		return false;
@@ -34,12 +36,6 @@ module.exports = function () {
 	// Handle case when target is a string or something (possible in deep copy)
 	if ( typeof target !== "object" && typeof target !== "function") {
 		target = {};
-	}
-
-	// extend jQuery itself if only one argument is passed
-	if ( length === i ) {
-		target = this;
-		--i;
 	}
 
 	for ( ; i < length; i++ ) {


### PR DESCRIPTION
1. `hasOwn` not defined - this causes a `ReferenceError` when deep cloning an object which has another object as one of its properties.
2. Falling back to `this` as the target when no additional arguments are passed results in properties being added to the global scope.
