### PR TITLE
use `isarray` for old browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,15 @@ var hasOwn = Object.prototype.hasOwnProperty;
 var toString = Object.prototype.toString;
 var undefined;
 
+// inlined from https://github.com/juliangruber/isarray
+var isArray = function (arr) {
+	if (Array.isArray) {
+		return Array.isArray.call(null, arr);
+	}
+
+  return toString.call(arr) === '[object Array]';
+};
+
 var isPlainObject = function isPlainObject(obj) {
 	'use strict';
 	if (!obj || toString.call(obj) !== '[object Object]') {
@@ -56,10 +65,10 @@ module.exports = function extend() {
 				}
 
 				// Recurse if we're merging plain objects or arrays
-				if (deep && copy && (isPlainObject(copy) || (copyIsArray = Array.isArray(copy)))) {
+				if (deep && copy && (isPlainObject(copy) || (copyIsArray = isArray(copy)))) {
 					if (copyIsArray) {
 						copyIsArray = false;
-						clone = src && Array.isArray(src) ? src : [];
+						clone = src && isArray(src) ? src : [];
 					} else {
 						clone = src && isPlainObject(src) ? src : {};
 					}

--- a/test/index.js
+++ b/test/index.js
@@ -621,3 +621,16 @@ test('pass in null; should create a valid object', function (t) {
 	t.end();
 });
 
+test('works without Array.isArray', function (t) {
+	var savedIsArray = Array.isArray;
+	delete Array.isArray;
+	var target = [];
+	var o1 = [1, 2, 3];
+	t.deepEqual(
+		extend(true, target, o1),
+		[1, 2, 3],
+		'It works without Array.isArray'
+	);
+	Array.isArray = savedIsArray;
+	t.end();
+});


### PR DESCRIPTION
IE<=9 has no Array.isArray.

It's the only change needed to make this module work in IE8.