### PR TITLE
Add ability to combine arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,39 @@ var hasOwn = Object.prototype.hasOwnProperty;
 var toString = Object.prototype.toString;
 var undefined;
 
+var combineArrays = function combineArrays() {
+  'use strict';
+  var combined = [];
+  for (var i = 0; i < arguments.length; i++) {
+		for (var n = 0; n < arguments[i].length; n++) {
+			if (combined.indexOf(arguments[i][n]) === -1) {
+				combined.push(arguments[i][n]);
+			}
+		}
+  }
+  combined.sort();
+  return combined;
+};
+
+var isPlainArray = function isPlainArray() {
+	'use strict';
+	if (!arguments || !arguments.length) {
+		return false;
+	}
+	for (var i = 0; i < arguments.length; i++) {
+		if (!Array.isArray(arguments[i])) {
+			return false;
+		}
+		for (var n = 0; n < arguments[i].length; n++) {
+			if (typeof arguments[i][n] != 'string' && typeof arguments[i][n] != 'number') {
+				return false;
+			}
+		}
+	}
+	
+	return true;
+};
+
 var isPlainObject = function isPlainObject(obj) {
 	'use strict';
 	if (!obj || toString.call(obj) !== '[object Object]') {
@@ -29,7 +62,8 @@ module.exports = function extend() {
 		target = arguments[0],
 		i = 1,
 		length = arguments.length,
-		deep = false;
+		deep = false,
+		combine = false;
 
 	// Handle a deep copy situation
 	if (typeof target === 'boolean') {
@@ -37,14 +71,26 @@ module.exports = function extend() {
 		target = arguments[1] || {};
 		// skip the boolean and the target
 		i = 2;
+		if (typeof arguments[1] === 'boolean') {
+			combine = arguments[1];
+			target = arguments[2] || {};
+			i = 3;
+		}
 	} else if ((typeof target !== 'object' && typeof target !== 'function') || target == null) {
 		target = {};
 	}
 
 	for (; i < length; ++i) {
 		options = arguments[i];
+		
 		// Only deal with non-null/undefined values
 		if (options != null) {
+			// Combine if we're combining plain arrays
+			if (combine && isPlainArray(options, target)) {
+				target = combineArrays(target, options);
+				continue;
+			}
+			
 			// Extend the base object
 			for (name in options) {
 				src = target[name];
@@ -65,7 +111,11 @@ module.exports = function extend() {
 					}
 
 					// Never move original objects, clone them
-					target[name] = extend(deep, clone, copy);
+					if (combine) {
+						target[name] = extend(deep, combine, clone, copy);
+					} else {
+						target[name] = extend(deep, clone, copy);
+					}
 
 				// Don't bring in undefined values
 				} else if (copy !== undefined) {


### PR DESCRIPTION
Hi all - I've used this module for a while now and have often needed the ability to combine arrays in a deep merge (instead of replacing array elements by index).

I tried to keep the code/syntax style the same by simply adding a second boolean argument to enable this feature:

```js
var extend = require('extend');
var x = extend(
    true,
    true,
    { y: [42] },
    { y: [4, 15, 16] },
    { y: [8, 23] }
);

// x = { y: [ 4, 8, 15, 16, 23, 42 ] }
```

All of the current tests pass and I'm willing to write more tests if needed. This feature only applies to plain arrays (arrays of strings or numbers only) and sorts the array once combined.

I hope others find this useful. Please consider this PR and/or provide feedback if you'd like to see a different implementation.

Thank you for your time and consideration!