### PR TITLE
A small optimization for isArray

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,12 @@
 var hasOwn = Object.prototype.hasOwnProperty;
 var toStr = Object.prototype.toString;
 
-var isArray = function isArray(arr) {
-	if (typeof Array.isArray === 'function') {
-		return Array.isArray(arr);
-	}
-
-	return toStr.call(arr) === '[object Array]';
-};
+var isArray = typeof Array.isArray === 'function'
+    ? Array.isArray
+    : function isArray(arr) {
+        return toStr.call(arr) === '[object Array]';
+    }
+;
 
 var isPlainObject = function isPlainObject(obj) {
 	'use strict';


### PR DESCRIPTION
When `Array.isArray` is available, use it directly, to avoid an extra function call.
