### PR TITLE
Add an example to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ npm install extend
 
 *Extend one object with one or more others, returning the modified object.*
 
+**Example:**
+
+``` js
+var extend = require('extend');
+extend(targetObject, object1, object2);
+```
+
 Keep in mind that the target object will be modified, and will be returned from extend().
 
 If a boolean true is specified as the first argument, extend performs a deep copy, recursively copying any objects it finds. Otherwise, the copy will share structure with the original object(s).


### PR DESCRIPTION
The current documentation does not state explicitly that this module returns the extend function. Add an example that includes the `require` call that clarifies this.