### PR TITLE
added support for buffers in deep cloning

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,9 +32,11 @@ var isPlainObject = function isPlainObject(obj) {
 };
 
 var isBuffer = function isBuffer(buff) {
-	if(typeof Buffer.isBuffer === 'function') return Buffer.isBuffer(buff);
-	else if(typeof Buffer === 'function') return buff instanceof Buffer;
-	return false;
+	if (typeof Buffer === 'function' && typeof Buffer.isBuffer === 'function') {
+		return Buffer.isBuffer(buff);
+	} else {
+		return false;
+	}
 };
 
 module.exports = function extend() {

--- a/index.js
+++ b/index.js
@@ -31,6 +31,12 @@ var isPlainObject = function isPlainObject(obj) {
 	return typeof key === 'undefined' || hasOwn.call(obj, key);
 };
 
+var isBuffer = function isBuffer(buff) {
+	if(typeof Buffer.isBuffer === 'function') return Buffer.isBuffer(buff);
+	else if(typeof Buffer === 'function') return buff instanceof Buffer;
+	return false;
+};
+
 module.exports = function extend() {
 	var options, name, src, copy, copyIsArray, clone,
 		target = arguments[0],
@@ -60,7 +66,9 @@ module.exports = function extend() {
 				// Prevent never-ending loop
 				if (target !== copy) {
 					// Recurse if we're merging plain objects or arrays
-					if (deep && copy && (isPlainObject(copy) || (copyIsArray = isArray(copy)))) {
+					if (deep && copy && isBuffer(copy)) {
+						target[name] = new Buffer(copy);
+					} else if (deep && copy && (isPlainObject(copy) || (copyIsArray = isArray(copy)))) {
 						if (copyIsArray) {
 							copyIsArray = false;
 							clone = src && isArray(src) ? src : [];

--- a/index.js
+++ b/index.js
@@ -93,4 +93,3 @@ module.exports = function extend() {
 	// Return the modified object
 	return target;
 };
-

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,6 @@
 
 var extend = require('../index');
 var test = require('tape');
-var fs = require('fs');
 
 var str = 'me a test';
 var integer = 10;

--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,7 @@
 
 var extend = require('../index');
 var test = require('tape');
+var fs = require('fs');
 
 var str = 'me a test';
 var integer = 10;
@@ -581,6 +582,18 @@ test('deep clone', function (t) {
 		}
 	}, 'deep is unchanged after setting target property');
 	// ----- NEVER USE EXTEND WITH THE ABOVE SITUATION ------------------------------
+	t.end();
+});
+
+test('deep clone; buffers are duplicated', function (t) {
+	var buff = fs.readFileSync('./index.js');
+
+	var target = extend(true, {}, { buff: buff });
+
+	t.equal(Buffer.isBuffer(target.buff), true, 'target buffer is buffer');
+	t.equal(target.buff != buff, true, 'buffers have been cloned');
+	t.deepEqual(target.buff, buff, 'buffers contain the same data');
+
 	t.end();
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -587,7 +587,7 @@ test('deep clone', function (t) {
 
 test('deep clone; buffers are duplicated', function (t) {
 	var buff = new Buffer(16);
-	buff.write("some string", 0, "ascii");
+	buff.write('some string', 0, 'ascii');
 
 	var target = extend(true, {}, { buff: buff });
 

--- a/test/index.js
+++ b/test/index.js
@@ -586,7 +586,8 @@ test('deep clone', function (t) {
 });
 
 test('deep clone; buffers are duplicated', function (t) {
-	var buff = fs.readFileSync('./index.js');
+	var buff = new Buffer(16);
+	buff.write("some string", 0, "ascii");
 
 	var target = extend(true, {}, { buff: buff });
 


### PR DESCRIPTION
Currently, deep cloning considers buffers as objects which can create issues
