### PR TITLE
Curcular error with deep copy

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ module.exports = function extend() {
 				// Prevent never-ending loop
 				if (target !== copy) {
 					// Recurse if we're merging plain objects or arrays
-					if (deep && copy && (isPlainObject(copy) || (copyIsArray = isArray(copy)))) {
+					if (deep && copy && copy !== options && (isPlainObject(copy) || (copyIsArray = isArray(copy)))) {
 						if (copyIsArray) {
 							copyIsArray = false;
 							clone = src && isArray(src) ? src : [];


### PR DESCRIPTION
I was looking where program falls in recursion for hour)

Its just object had link to itself... Check yourself: `a = {}; a.a = a; extend( true, {}, a )`

Hope it will save some time for somebody.
