### PR TITLE
Specify files to publish to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-# gitignore
-node_modules
-
-# Only apps should have lockfiles
-npm-shrinkwrap.json
-package-lock.json
-yarn.lock

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
 	},
 	"license": "MIT",
 	"files": [
-		"index.js",
-		"component.json"
+		"index.js"
 	]
 }

--- a/package.json
+++ b/package.json
@@ -36,5 +36,9 @@
 		"safe-publish-latest": "^1.1.4",
 		"tape": "^4.13.0"
 	},
-	"license": "MIT"
+	"license": "MIT",
+	"files": [
+		"index.js",
+		"component.json"
+	]
 }


### PR DESCRIPTION
Currently a number of not necessary files are being published to `npm`. This includes files such as `.editorconfig` and `.travis.yml`. Considering that they make up more than half of the filesize of this package, it would be worthwhile to not publish them. This PR does this using the [`files`](https://docs.npmjs.com/files/package.json#files) field in the `package.json`. 

I've chosen to use the `files` field instead of the `.npmignore`, because the latter is more of a whack a mole and has to be kept in sync with the `.gitignore`.